### PR TITLE
Including DadaGP article on the list

### DIFF
--- a/dl4m.bib
+++ b/dl4m.bib
@@ -1,3 +1,10 @@
+@inproceedings{Sarmento2021,
+    author = {Sarmento, Pedro and Kumar, Adarsh and Carr, CJ and Zukowski, Zack and Barthet, Mathieu and Yang, Yi-Hsuan},
+    booktitle = {Proceedings of the 22nd International Society for Music Information Retrieval Conference},
+    title = {DadaGP: A dataset of tokenized GuitarPro songs for sequence models},
+    year = {2021},
+}
+
 @inproceedings{Bharucha1988,
   author = {Bharucha, J.},
   booktitle = {Proceedings of the First Workshop on Artificial Intelligence and Music},


### PR DESCRIPTION
I'm having trouble running dl4m.py, as instructed on https://github.com/otnemrasordep/awesome-deep-learning-music/blob/master/CONTRIBUTING.md, due to version incompatibility. 
However, I did include the bibtex info for DadaGP here, at the beginning. Would it work if you could kindly run the script for me? 
Thank you very much!